### PR TITLE
Dev destruction

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1344,7 +1344,7 @@ typedef enum {
 #define SE_BladedBloodCap				565
 #define SE_ProcCapPerAgi				567
 #define SE_ProcCapPerDex				568
-
+#define SE_ShadowJujitsu 569;
 
 
 // LAST

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1346,6 +1346,7 @@ typedef enum {
 #define SE_ProcCapPerDex				568
 //recoil just picked this int!
 #define SE_ShadowJujitsu 				569
+#define SE_Devestating_Destruction 				570
 
 // LAST
 

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1344,8 +1344,8 @@ typedef enum {
 #define SE_BladedBloodCap				565
 #define SE_ProcCapPerAgi				567
 #define SE_ProcCapPerDex				568
-#define SE_ShadowJujitsu 569;
-
+//recoil just picked this int!
+#define SE_ShadowJujitsu 				569
 
 // LAST
 

--- a/zone/aa.h
+++ b/zone/aa.h
@@ -165,6 +165,7 @@ typedef enum {
 	aaHotStuff		= 663,
 	aaAbjurerSupreme = 668,
 	aaChaosBlade	= 673,
+	aaShadowJujitsu = 674,
 
 	// T5 Passives
 	aaFistsOfSteel = 678,

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -18,7 +18,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "../common/global_define.h"
 #include "../common/eq_constants.h"
-#include "../common/eq_packet_structs.h"
+#include "../common/eqdodge_packet_structs.h"
 #include "../common/rulesys.h"
 #include "../common/spdat.h"
 #include "../common/strings.h"
@@ -196,7 +196,7 @@ int Mob::GetTotalToHit(EQ::skills::SkillType skill, int chance_mod)
 
 		accuracy += (int)ceil(RuleR(StatBuff, DexterityAccuracyPerLevel) * GetLevel() * dex);
 	}
-	
+
 	if (chance_mod > 0) // multiplier
 		accuracy *= chance_mod;
 
@@ -646,6 +646,8 @@ bool Mob::AvoidDamage(Mob *other, DamageHitInfo &hit)
 		}
 		if (zone->random.Roll(chance)) {
 			hit.damage_done = DMG_DODGED;
+			//proc shadow jujitsu
+			CheckShadowJuJu();
 			return true;
 		}
 	}
@@ -1591,7 +1593,7 @@ void Mob::DoAttack(Mob *other, DamageHitInfo &hit, ExtraAttackOptions *opts, boo
 			}
 
 			procs = DoMidAttackAAs(other, hit, procs);
-			
+
 			LogCombat("Final damage after all reductions: [{}]", hit.damage_done);
 		}
 		else {
@@ -2229,7 +2231,7 @@ bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::Skil
 		QServ->PlayerLogEvent(Player_Log_Deaths, CharacterID(), event_desc);
 	}
 
-	
+
 
 	if (player_event_logs.IsEventEnabled(PlayerEvent::DEATH)) {
 		auto e = PlayerEvent::DeathEvent{
@@ -2882,7 +2884,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 					if (!GetOwner() || (GetOwner() && !GetOwner()->IsClient())) {
 						give_exp_client->AddEXP(ExpSource::Kill, final_exp, con_level, false, this);
 
-						
+
 
 						if (
 							killer_mob &&
@@ -6021,19 +6023,19 @@ const DamageTable Mob::GetDamageTable() const
 		{ 410, 85,  40 }, // 104
 		{ 415, 85,  40 }, // 105
 	};
-	
-	
+
+
 	int max, chance, minus = 0;
 	int level = GetLevel();
 	DamageTable myTable;
 	if (IsClient()) {
 
 		max = 200 + 5 * level;
-		if (level > 30)	
+		if (level > 30)
 			max *= 1 + 0.05f * (level - 30);
 
 		chance = 25 + level;
-		
+
 		if (chance > 95)
 			chance = 95;
 
@@ -6153,10 +6155,10 @@ void Mob::ApplyDamageTable(DamageHitInfo &hit)
 	if (str > softcap)
 		str = static_cast<int>(ceil(softcap + (str - softcap) * softcapRet));
 
-	if (IsClient() && RuleB(StatBuff, StatBuffEnabled)) 
+	if (IsClient() && RuleB(StatBuff, StatBuffEnabled))
 		hit.offense += str;
 
-	
+
 
 	// this was parsed, but we do see the min of 10 and the normal minus factor is 105, so makes sense
 	// if (hit.offense < 115)
@@ -6196,8 +6198,8 @@ void Mob::ApplyDamageTable(DamageHitInfo &hit)
 	int extrapercent = zone->random.Roll0(basebonus);
 	int percent = std::min(100 + extrapercent, max);
 	hit.damage_done = (hit.damage_done * percent) / 100;
-	
-	
+
+
 
 	if (IsWarriorClass() && GetLevel() > 54)
 		hit.damage_done++;
@@ -7290,6 +7292,39 @@ int Mob::CheckHeadshotAA(Mob* target, DamageHitInfo& hit)
 }
 
 
+int Mob::CheckShadowJujitsu()
+{
+
+	if (!IsClient()) return 0;
+
+	uint32 ShadowJujuChance = aabonuses.ShadowJujitsu[0] + spellbonuses.ShadowJujitsu[0] + itembonuses.ShadowJujitsu[0];
+	uint32 ShadowJuju = aabonuses.ShadowJujitsu[0] + spellbonuses.ShadowJujitsu[0] + itembonuses.ShadowJujitsu[0];
+
+	int agi = client->GetAGI();
+
+	if (zone->random.Int(1, 100) <= ShadowJuju )
+	{
+
+		//presumablyv some max pet sanity count here
+		std::string query = fmt::format(
+			"SELECT id, name FROM spell_new WHERE spellid = {}",
+			spell_id
+		);
+
+		auto results = database.QueryDatabase(query);
+	if (!results.Success()) {
+			return false; // Query failed, do not allow scribing.
+		}
+		//3 dg ranks:
+		//4552, 4553, 4554.
+		uint16 spell = 4552;
+		 client->MakePet(spell, 4, "Shadow Clone");
+	}
+
+	return 1;
+}
+
+
 
 bool Mob::CheckDualWield()
 {
@@ -7420,7 +7455,7 @@ int Mob::DoPreAttackAAs(Mob* target, int procs_remaining) {
 }
 
 int Mob::DoEarlyAttackAAs(Mob* target, DamageHitInfo& hit, int procs_remaining) {
-	// These Abilities are considered during the attack, before we confirm a hit. 
+	// These Abilities are considered during the attack, before we confirm a hit.
 	// Accuracy changes and any effect that does not require an attack to occur (ie blackguard's initiative) handled here.
 	// Returns count of procs that count against proc cap that have occurred.
 	if (!IsClient())
@@ -7439,13 +7474,13 @@ int Mob::DoMidAttackAAs(Mob* target, DamageHitInfo &hit, int procs_remaining) {
 	// Only works on YOUR target.
 	if (!IsClient())
 		return procs_remaining;
-	
+
 	// headshot
 	if (procs_remaining > 1)
 		procs_remaining -= CheckHeadshotAA(target, hit);
 
 	HandleDamageMultipliers(target, hit);
-	
+
 
 
 	return procs_remaining;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -18,7 +18,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "../common/global_define.h"
 #include "../common/eq_constants.h"
-#include "../common/eqdodge_packet_structs.h"
+#include "../common/eq_packet_structs.h"
 #include "../common/rulesys.h"
 #include "../common/spdat.h"
 #include "../common/strings.h"
@@ -647,7 +647,7 @@ bool Mob::AvoidDamage(Mob *other, DamageHitInfo &hit)
 		if (zone->random.Roll(chance)) {
 			hit.damage_done = DMG_DODGED;
 			//proc shadow jujitsu
-			CheckShadowJuJu();
+			CheckShadowJujitsu();
 			return true;
 		}
 	}
@@ -7300,25 +7300,16 @@ int Mob::CheckShadowJujitsu()
 	uint32 ShadowJujuChance = aabonuses.ShadowJujitsu[0] + spellbonuses.ShadowJujitsu[0] + itembonuses.ShadowJujitsu[0];
 	uint32 ShadowJuju = aabonuses.ShadowJujitsu[0] + spellbonuses.ShadowJujitsu[0] + itembonuses.ShadowJujitsu[0];
 
-	int agi = client->GetAGI();
+	//int agi = client->GetAGI();
 
 	if (zone->random.Int(1, 100) <= ShadowJuju )
 	{
-
-		//presumablyv some max pet sanity count here
-		std::string query = fmt::format(
-			"SELECT id, name FROM spell_new WHERE spellid = {}",
-			spell_id
-		);
-
-		auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
-			return false; // Query failed, do not allow scribing.
-		}
+		Client* client = this->CastToClient();
 		//3 dg ranks:
 		//4552, 4553, 4554.
 		uint16 spell = 4552;
-		 client->MakePet(spell, 4, "Shadow Clone");
+
+		 client->MakePet(spell, "petAnimation", "Shadow Clone");
 	}
 
 	return 1;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2022,6 +2022,10 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->DeepGougeBase += base_value;
 			newbon->DeepGougeIntScale += limit_value;
 			break;
+		case SE_Devestating_Destruction:
+			newbon->DevestatingSestruction[0] += base_value;
+			newbon->DevestatingSestruction[1] += limit_value;
+			break;
 
 		case SE_ShadowJujitsu:
 			newbon->ShadowJujitsu[0] += base_value;
@@ -4151,10 +4155,18 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				new_bonus->WayOfTheBarbarian[1] += limit_value;
 				LogDebug("Way of the barbarian applied: {} {}", effect_value, limit_value);
 				break;
+
+
 			case SE_ShadowJujitsu:
 				new_bonus->ShadowJujitsu[0] += effect_value;
 				new_bonus->ShadowJujitsu[1] += limit_value;
 				break;
+
+			case SE_Devestating_Destruction:
+			new_bonus->DevestatingSestruction[0] += effect_value;
+			new_bonus->DevestatingSestruction[1] += limit_value;
+			break;
+
 			case SE_BlackguardsInitiative:
 				new_bonus->BlackguardsInitiative[0] += effect_value;
 				new_bonus->BlackguardsInitiative[1] += limit_value;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2014,7 +2014,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		case SE_ChainAttackThrowing:
 			newbon->throwingMultiAttack += base_value;
 			break;
-
+SE
 		case SE_BladedBloodCap:
 			newbon->maxBladedBloodCharges += base_value;
 			break;
@@ -2024,8 +2024,8 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 
 		case SE_ShadowJujitsu:
-			newbon->SE_ShadowJujitsu[0] += base_value;
-			newbon->SE_ShadowJujitsu[1] += limit_value;
+			newbon->ShadowJujitsu[0] += base_value;
+			newbon->ShadowJujitsu[1] += limit_value;
 
 		case SE_WayOfTheBarbarian:
 			newbon->WayOfTheBarbarian[0] += base_value;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -909,7 +909,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		case SE_CHA:
 			newbon->CHA += base_value;
 			break;
-		
+
 		case SE_WaterBreathing:
 			// handled by client
 			break;
@@ -2022,6 +2022,10 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->DeepGougeBase += base_value;
 			newbon->DeepGougeIntScale += limit_value;
 			break;
+
+		case SE_ShadowJujitsu:
+			newbon->SE_ShadowJujitsu[0] += base_value;
+			newbon->SE_ShadowJujitsu[1] += limit_value;
 
 		case SE_WayOfTheBarbarian:
 			newbon->WayOfTheBarbarian[0] += base_value;
@@ -4146,6 +4150,9 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				new_bonus->WayOfTheBarbarian[1] += limit_value;
 				LogDebug("Way of the barbarian applied: {} {}", effect_value, limit_value);
 				break;
+			case SE_ShadowJujitsu:
+				new_bonus->ShadowJujitsu[0] += effect_value;
+				new_bonus->ShadowJujitsu[1] += limit_value;
 			case SE_BlackguardsInitiative:
 				new_bonus->BlackguardsInitiative[0] += effect_value;
 				new_bonus->BlackguardsInitiative[1] += limit_value;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2014,7 +2014,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		case SE_ChainAttackThrowing:
 			newbon->throwingMultiAttack += base_value;
 			break;
-SE
+
 		case SE_BladedBloodCap:
 			newbon->maxBladedBloodCharges += base_value;
 			break;
@@ -2026,6 +2026,7 @@ SE
 		case SE_ShadowJujitsu:
 			newbon->ShadowJujitsu[0] += base_value;
 			newbon->ShadowJujitsu[1] += limit_value;
+			break;
 
 		case SE_WayOfTheBarbarian:
 			newbon->WayOfTheBarbarian[0] += base_value;
@@ -4153,6 +4154,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			case SE_ShadowJujitsu:
 				new_bonus->ShadowJujitsu[0] += effect_value;
 				new_bonus->ShadowJujitsu[1] += limit_value;
+				break;
 			case SE_BlackguardsInitiative:
 				new_bonus->BlackguardsInitiative[0] += effect_value;
 				new_bonus->BlackguardsInitiative[1] += limit_value;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2023,8 +2023,8 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->DeepGougeIntScale += limit_value;
 			break;
 		case SE_Devestating_Destruction:
-			newbon->DevestatingSestruction[0] += base_value;
-			newbon->DevestatingSestruction[1] += limit_value;
+			newbon->DevestatingDestruction[0] += base_value;
+			newbon->DevestatingDestruction[1] += limit_value;
 			break;
 
 		case SE_ShadowJujitsu:
@@ -4163,8 +4163,8 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 
 			case SE_Devestating_Destruction:
-			new_bonus->DevestatingSestruction[0] += effect_value;
-			new_bonus->DevestatingSestruction[1] += limit_value;
+			new_bonus->DevestatingDestruction[0] += effect_value;
+			new_bonus->DevestatingDestruction[1] += limit_value;
 			break;
 
 			case SE_BlackguardsInitiative:

--- a/zone/common.h
+++ b/zone/common.h
@@ -523,6 +523,7 @@ struct StatBonuses {
 	int32 maxBladedBloodCharges;
 	int32 throwingMultiAttack;
 	int32 procCapBonus;
+	int32 ShadowJujitsu[2];
 
 	//EQEMU AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.

--- a/zone/common.h
+++ b/zone/common.h
@@ -524,6 +524,7 @@ struct StatBonuses {
 	int32 throwingMultiAttack;
 	int32 procCapBonus;
 	int32 ShadowJujitsu[2];
+	int32 DevestatingDestruction[2];
 
 	//EQEMU AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -125,6 +125,12 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 			if (target) {
 				value += int(base_value*target->GetVulnerability(this, spell_id, 0) / 100) * ratio / 100;
 				value -= target->GetFcDamageAmtIncoming(this, spell_id);
+
+						//AOT AA: Devestating Destruction
+				if (IsClient() && aabonuses.DevestatingDestruction[0] && target->getDebuffCount() > aabonuses.DevestatingDestruction[0] && aabonuses.DevestatingDestruction[1]){
+					value += base_value*aabonuses.DevestatingDestruction[1];
+				}
+
 			}
 
 			/* duration int buff!
@@ -188,7 +194,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 				MessageString(Chat::SpellCrit, YOU_CRIT_BLAST, itoa(-value));
 			}
 
-			
+
 
 			return value;
 		}
@@ -205,6 +211,11 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 	if (target) {
 		value += base_value*target->GetVulnerability(this, spell_id, 0) / 100;
 		value -= target->GetFcDamageAmtIncoming(this, spell_id);
+		//AOT AA: Devestating Destruction
+		if (IsClient() && aabonuses.DevestatingDestruction[0] && target->getDebuffCount() > aabonuses.DevestatingDestruction[0] && aabonuses.DevestatingDestruction[1]){
+			value += base_value*aabonuses.DevestatingDestruction[1];
+		}
+
 	}
 
 	value -= GetFocusEffect(focusFcDamageAmtCrit, spell_id);
@@ -263,7 +274,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 		}
 	}
 
-	
+
 
 	return value;
 }
@@ -628,7 +639,7 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 		}
 
 
-		
+
 		if (temp_targ->IsClient() && RuleB(StatBuff, StatBuffEnabled)) {
 
 			float mit = temp_targ->CastToClient()->CalcEHPMult();

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -127,7 +127,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 				value -= target->GetFcDamageAmtIncoming(this, spell_id);
 
 						//AOT AA: Devestating Destruction
-				if (IsClient() && aabonuses.DevestatingDestruction[0] && target->getDebuffCount() > aabonuses.DevestatingDestruction[0] && aabonuses.DevestatingDestruction[1]){
+				if (IsClient() && aabonuses.DevestatingDestruction[0] && target->GetDebuffCount() > aabonuses.DevestatingDestruction[0] && aabonuses.DevestatingDestruction[1]){
 					value += base_value*aabonuses.DevestatingDestruction[1];
 				}
 
@@ -212,7 +212,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 		value += base_value*target->GetVulnerability(this, spell_id, 0) / 100;
 		value -= target->GetFcDamageAmtIncoming(this, spell_id);
 		//AOT AA: Devestating Destruction
-		if (IsClient() && aabonuses.DevestatingDestruction[0] && target->getDebuffCount() > aabonuses.DevestatingDestruction[0] && aabonuses.DevestatingDestruction[1]){
+		if (IsClient() && aabonuses.DevestatingDestruction[0] && target->GetDebuffCount() > aabonuses.DevestatingDestruction[0] && aabonuses.DevestatingDestruction[1]){
 			value += base_value*aabonuses.DevestatingDestruction[1];
 		}
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1124,7 +1124,7 @@ public:
 
 	bool invulnerable;
 	bool qglobal;
-	
+
 	inline std::vector<uint32> GetBotAttackFlags() { return bot_attack_flags; }
 	inline void SetBotAttackFlag(uint32 value) { bot_attack_flags.push_back(value); }
 	inline void ClearBotAttackFlags() { bot_attack_flags.clear(); }
@@ -1697,10 +1697,10 @@ protected:
 	Timer tic_timer;
 	Timer mana_timer;
 	int32 dw_same_delay;
-	
+
 	// AoT Custom
 
-
+	int64 GetDebuffCount();
 
 	int deep_gouge_decay = 0;
 	uint32 deep_gouge_stacks;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -216,6 +216,7 @@ public:
 	int CheckBlackguardAA(Mob *target);
 	int CheckHeadshotAA(Mob* target, DamageHitInfo& hit);
 	int CheckDeepGougeAA(Mob* target, DamageHitInfo& hit);
+	int CheckShadowJujitsu();
 
 	//Attack
 	virtual void RogueBackstab(Mob* other, bool min_damage = false, int ReuseTime = 10);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7468,6 +7468,8 @@ int64 Mob::GetFcDamageAmtIncoming(Mob *caster, int32 spell_id, bool from_buff_ti
 int64 Mob::GetDebuffCount()
 {
 	int64 debuffCount = 0;
+	int buff_count = GetMaxTotalSlots();
+
 	for(int slot = 0; slot < buff_count; slot++) {
 		if (IsValidSpell(buffs[slot].spellid) &&
 			IsDetrimentalSpell(buffs[slot].spellid))

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7465,6 +7465,19 @@ int64 Mob::GetFcDamageAmtIncoming(Mob *caster, int32 spell_id, bool from_buff_ti
 	dmg += GetFocusEffect(focusFcSpellDamageAmtIncomingPC, spell_id, caster, from_buff_tic); //SPA 484 SE_Fc_Spell_Damage_Amt_IncomingPC
 	return dmg;
 }
+int64 Mob::GetDebuffCount()
+{
+	int64 debuffCount = 0;
+	for(int slot = 0; slot < buff_count; slot++) {
+		if (IsValidSpell(buffs[slot].spellid) &&
+			IsDetrimentalSpell(buffs[slot].spellid))
+		{
+			debuffCount++;
+		}
+	}
+
+	return debuffCount;
+}
 
 int64 Mob::GetFocusIncoming(focusType type, int effect, Mob *caster, uint32 spell_id) {
 


### PR DESCRIPTION
Devestating Destruction:

As written:

> if the target has 3 or more detrimental spells, your nukes deal bonus damage.

As coded:

SE 0 is number of debuffs required to proc, SE 1 is damage modifier

depends on #9  being merged first
